### PR TITLE
about cef column

### DIFF
--- a/ATPDocs/cef-format-sa.md
+++ b/ATPDocs/cef-format-sa.md
@@ -38,7 +38,7 @@ The following fields and their values are forwarded to your SIEM:
 |---------|---------------|
 |start|start time of the alert|
 |suser|account (usually the user account) involved in the alert|
-|machine account|account (usually the user account) involved in the alert|
+|shost|account (usually the computer account) involved in the alert|
 |outcome|when relevant, a success or failure of the suspicious activity in the alert|
 |msg|description of the alert|
 |cnt|for alerts that have a count of the number of times that activity happened (for example, brute force has an amount of guessed passwords)|


### PR DESCRIPTION
I can't find the "machine account" column in CEF output.
I guess it may be referring to "shost" for describing computer account.
Please kindly review my suggestion and I appreciate if you could modify it.
> |machine account|account (usually the user account) involved in the alert|