### PR TITLE
Update AATP port prerequsites

### DIFF
--- a/ATPDocs/prerequisites.md
+++ b/ATPDocs/prerequisites.md
@@ -189,9 +189,9 @@ The following table lists the minimum ports that the Azure ATP sensor requires:
 |Syslog (optional)|TCP/UDP|514, depending on configuration|SIEM Server|Azure ATP sensor|Inbound|
 |RADIUS|UDP|1813|RADIUS|Azure ATP sensor|Inbound|
 |**NNR ports**\*||||||
-|NTLM over RPC|TCP|Port 135|ATP sensors|All devices on network|Inbound|
-|NetBIOS|UDP|137|ATP sensors|All devices on network|Inbound|
-|RDP|TCP|3389, only the first packet of Client hello|ATP sensors|All devices on network|Inbound|
+|NTLM over RPC|TCP|Port 135|ATP sensors|All devices on network|Outbound|
+|NetBIOS|UDP|137|ATP sensors|All devices on network|Outbound|
+|RDP|TCP|3389, only the first packet of Client hello|ATP sensors|All devices on network|Outbound|
 
 \* One of these ports is required, but we recommend opening all of them.
 


### PR DESCRIPTION
I think these port requirement in NNR contains mistakes. That is Direction.

From the view point of an Azure ATP sensor, NNR session occurs from AATP sensor to each clients.
This means there is outbound communication from Azure ATP to each client, not inbound communication.
# For example, Direction of DNS traffic is OUTBOUND from from AATP sensor to DNS Server 

I think it needs to be corrected because the wrong orientation can cause the customer to mis-configure their firewall device.
Much appreciate your kindly review.