### PR TITLE
Add step to gMSA about required rights to sign in as service

### DIFF
--- a/ATPDocs/install-step2.md
+++ b/ATPDocs/install-step2.md
@@ -31,7 +31,8 @@ In this quickstart, you'll connect [!INCLUDE [Product long](includes/product-lon
 
 1. Create a [gMSA account](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_CreateGMSA). Make sure to check the [prerequisites](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_gMSA_Req) carefully.
 2. Create a new [security group containing all your domain controllers with sensors (running Windows Server 2012 or above)](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_AddMemberHosts) with permissions to retrieve the gMSA account's password. (Recommended)
-3. Grant the gMSA account "Log on as a service" right in the Default Domain Controllers Policy and any policy that impacts the machines on which the sensor is installed on. This ensures that the Azure Advanced Threat Protection Sensor service can start.
+>[!NOTE]
+>If the user rights assignment policy **Log on as a service** is configured for this domain controller, impersonation will fail unless the gMSA account is granted the **Log on as a service** permission. For more information, see [Sensor failed to retrieve group Managed Service Account (gMSA) credentials](troubleshooting-known-issues.md#cause-2)
 
 ## Provide a username and password to connect to your Active Directory Forest
 

--- a/ATPDocs/install-step2.md
+++ b/ATPDocs/install-step2.md
@@ -30,7 +30,8 @@ In this quickstart, you'll connect [!INCLUDE [Product long](includes/product-lon
 ### How to set up a gMSA account
 
 1. Create a [gMSA account](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_CreateGMSA). Make sure to check the [prerequisites](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_gMSA_Req) carefully.
-1. Create a new [security group containing all your domain controllers with sensors (running Windows Server 2012 or above)](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_AddMemberHosts) with permissions to retrieve the gMSA account's password. (Recommended)
+2. Create a new [security group containing all your domain controllers with sensors (running Windows Server 2012 or above)](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_AddMemberHosts) with permissions to retrieve the gMSA account's password. (Recommended)
+3. Grant the gMSA account "Log on as a service" right in the Default Domain Controllers Policy and any policy that impacts the machines on which the sensor is installed on. This ensures that the Azure Advanced Threat Protection Sensor service can start.
 
 ## Provide a username and password to connect to your Active Directory Forest
 

--- a/ATPDocs/install-step2.md
+++ b/ATPDocs/install-step2.md
@@ -32,7 +32,7 @@ In this quickstart, you'll connect [!INCLUDE [Product long](includes/product-lon
 1. Create a [gMSA account](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_CreateGMSA). Make sure to check the [prerequisites](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_gMSA_Req) carefully.
 2. Create a new [security group containing all your domain controllers with sensors (running Windows Server 2012 or above)](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts#BKMK_AddMemberHosts) with permissions to retrieve the gMSA account's password. (Recommended)
 >[!NOTE]
->If the user rights assignment policy **Log on as a service** is configured for this domain controller, impersonation will fail unless the gMSA account is granted the **Log on as a service** permission. For more information, see [Sensor failed to retrieve group Managed Service Account (gMSA) credentials](troubleshooting-known-issues.md#cause-2)
+>If the user rights assignment policy **Log on as a service** is configured for this domain controller, impersonation will fail unless the gMSA account is granted the **Log on as a service** permission. For more information, see [Sensor failed to retrieve group Managed Service Account (gMSA) credentials](troubleshooting-known-issues.md#cause-2).
 
 ## Provide a username and password to connect to your Active Directory Forest
 


### PR DESCRIPTION
If the account does not have the right to sign in as service then the service will not start. This is only documented elsewhere on Twitter that I could see, so adding it here as it took hours to find and resolve!