### PR TITLE
Add the requirement to "log on as a service"

### DIFF
--- a/ATPDocs/manage-action-accounts.md
+++ b/ATPDocs/manage-action-accounts.md
@@ -17,6 +17,7 @@ We recommend you create the gMSA account Defender for Identity will use to take 
 ## Create and configure the action account
 
 1. On a domain controller in your domain, create a new gMSA account, following the instructions in [Getting started with Group Managed Service Accounts](/windows-server/security/group-managed-service-accounts/getting-started-with-group-managed-service-accounts).
+1. Assign the "Log on as a service" right to the gMSA account on each server which runs the Defender for Identity sensor.
 
 1. Grant the required permissions to the gMSA account.
     1. Open **Active Directory Users and Computers**.


### PR DESCRIPTION
We ran into this trouble when configuring our action account - if the account isn't granted the "Log on as a service" right, the action account will not function properly. This pull request adds a new step to add the appropriate permission for the account on each server.

In our environment, we updated the Default Domain Controller policy to accomplish the goal, but I felt that specifying that as the solution was too prescriptive - instead, I went with just saying what needed to happen.