### PR TITLE
Patch 2

### DIFF
--- a/ATPDocs/configure-windows-event-collection.md
+++ b/ATPDocs/configure-windows-event-collection.md
@@ -79,10 +79,6 @@ Modify the Advanced Audit Policies of your domain controller using the following
         ![Audit Security Group Management.](media/advanced-audit-policy-check-step-4.png)
 
 1. From an elevated command prompt type `gpupdate`.
-
-    > [!NOTE]
-    > This step should be performed on all domain controllers in the domain, or you can wait for the next refresh cycle to update them (by default within 90 minutes)
-
 1. After applying via GPO, the new events are visible in the Event Viewer, under **Windows Logs** -> **Security**.
 
 > [!NOTE]

--- a/ATPDocs/configure-windows-event-collection.md
+++ b/ATPDocs/configure-windows-event-collection.md
@@ -82,7 +82,7 @@ Modify the Advanced Audit Policies of your domain controller using the following
 1. After applying via GPO, the new events are visible in the Event Viewer, under **Windows Logs** -> **Security**.
 
 > [!NOTE]
-> If you choose to use a local security policy instead of using a group policy, make sure to add the **Account Logon**, **Account Management**, and **Security Options** audit logs in your local policy. If you are configuring the advanced audit policy, make sure to force the [audit policy subcategory](/windows/security/threat-protection/security-policy-settings/audit-force-audit-policy-subcategory-settings-to-override).
+> If you choose to use a local security policy instead of applying a group policy to your AD FS servers, make sure to add the **Account Logon**, **Account Management**, and **Security Options** audit logs in your local security policy. If you are configuring the advanced audit policy, make sure to force the [audit policy subcategory](/windows/security/threat-protection/security-policy-settings/audit-force-audit-policy-subcategory-settings-to-override).
 
 ### Event ID 8004
 


### PR DESCRIPTION
- Removed suggestion that you edit the same Group Policy on every domain controller. SYSVOL replication takes care of this for you.
- Clarified that local security policy can only be applied to AD FS servers