### PR TITLE
Remove Install gMSA

### DIFF
--- a/ATPDocs/directory-service-accounts.md
+++ b/ATPDocs/directory-service-accounts.md
@@ -211,22 +211,6 @@ C:\Windows\System32\dsacls.exe $params
 
 For more information about configuring read-only permissions on the Deleted Objects container, see the **Changing permissions on a deleted object container** section of the [View or Set Permissions on a Directory Object](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc816824(v=ws.10)) article.
 
-## Install the gMSA account
-
-To install the gMSA account, run locally (as an administrator) on each of the servers, the following command:
-
-```powershell
-# Import the required PowerShell module:
-Import-Module ActiveDirectory
-
-# Install the gMSA account
-Install-ADServiceAccount -Identity 'mdiSvc01'
-```
-
->[!NOTE]
->Trying to intall a gMSA from a root domain on a child domain will fail, as the Install-ADServiceAccount cmdlet can only look for the account on the local domain.
->There's no need to install the gMSA for Defender for Identity sensors to be able to use the gMSA. It is only required for the password rotation mechanism.
-
 ## How to validate that the domain controller can retrieve the gMSA's password
 
 To validate that the server has the required permissions to retrieve the gMSA's password, run the following PowerShell command:


### PR DESCRIPTION
This is not applicable to gMSAs, only standalone MSAs

The note is correct in indicating that it is not necessary for gMSAs to work. It is incorrect that it is required for the password rotation mechanism. The password is not rotated but rather derived from the KDS Root Key and accountKeyId + createdTime + interval, and it is retrieved as needed by the gMSA. The only thing Install-ADServiceAccount does is pre-cache which is unnecessary given the account is running on a domain controller and will never have connectivity issues with a domain controller.

I recommend removing this step as it is confusing and unnecessary.