### PR TITLE
Update install-sensor.md

### DIFF
--- a/ATPDocs/deploy/install-sensor.md
+++ b/ATPDocs/deploy/install-sensor.md
@@ -95,7 +95,7 @@ The Defender for Identity silent installation is configured to automatically res
 
 Make sure to schedule a silent installation only during a maintenance window. Because of a Windows Installer bug, the *norestart* flag can't be reliably used to make sure the server doesn't restart.
 
-To track your deployment progress, monitor the Defender for Identity installer logs, which are located in `%AppData%\Local\Temp`.
+To track your deployment progress, monitor the Defender for Identity installer logs, which are located in `%localappdata%\Temp`.
 
 ### Silent installation via a deployment system
 


### PR DESCRIPTION
in line 98 the path is logs path is not correct.

%appdata% points to C:\Users\USERNAME\AppData\Roaming

%localappdata% points to C:\Users\USERNAME\AppData\Local\

for that reason the doc should refer the customers to %localappdata%\Temp where the logs actually reside, rather than %AppData%\Local\Temp that is a non-existing path/folder.